### PR TITLE
fix: solve ForstekFooter warning #34

### DIFF
--- a/src/components/ForstekFooter/index.js
+++ b/src/components/ForstekFooter/index.js
@@ -4,7 +4,14 @@ import Styled from './StyledComponent'
 
 const ForstekFooter = () => (
   <Styled.ForstekFooter>
-    Made with &#129505; by &nbsp;
+    Made with &nbsp; 
+      <span 
+        role='img'
+        aria-label='love'
+      >
+        &#129505;
+      </span>
+      &nbsp; by &nbsp;
     <a
       href='https://www.forstek.co/'
     >


### PR DESCRIPTION
Warning has been solved by putting emoji inside <span>, add its role as 'img' and adding aria-label = 'love'.

Merge into release/1.0, not staging. Before this is a mistake, but has been reverted.

Closes #34 
